### PR TITLE
C++工程，适配到cocos2d-x 3.1 rc0

### DIFF
--- a/demos/cocos2d-x-3.x/DragonBonesCppDemos/proj.win32/DragonBonesCppDemos.vcxproj
+++ b/demos/cocos2d-x-3.x/DragonBonesCppDemos/proj.win32/DragonBonesCppDemos.vcxproj
@@ -69,7 +69,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(EngineRoot)cocos\audio\include;$(EngineRoot)external;$(EngineRoot)external\chipmunk\include\chipmunk;$(EngineRoot)extensions;..\Classes;..;..\..\..\..\dragonbones;..\..\..\..\dragonbones\utils;..\..\..\..\renderer\cocos2d-x-3.x;..\..\..\..\dragonbones\animation;..\..\..\..\dragonbones\core;..\..\..\..\dragonbones\display;..\..\..\..\dragonbones\events;..\..\..\..\dragonbones\factories;..\..\..\..\dragonbones\objects;..\..\..\..\dragonbones\textures;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(EngineRoot)cocos\audio\include;$(EngineRoot)external;$(EngineRoot)external\chipmunk\include\chipmunk;$(EngineRoot)extensions;..\Classes;..;..\..\..\..\dragonbones;..\..\..\..\dragonbones\utils;..\..\..\..\renderer\cocos2d-x-3.x;..\..\..\..\dragonbones\animation;..\..\..\..\dragonbones\core;..\..\..\..\dragonbones\display;..\..\..\..\dragonbones\events;..\..\..\..\dragonbones\factories;..\..\..\..\dragonbones\objects;..\..\..\..\dragonbones\textures;$(EngineRoot)cocos\2d;$(EngineRoot)cocos\base;$(EngineRoot)cocos\renderer;$(EngineRoot)cocos\math;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USE_MATH_DEFINES;GL_GLEXT_PROTOTYPES;CC_ENABLE_CHIPMUNK_INTEGRATION=1;COCOS2D_DEBUG=1;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>

--- a/renderer/cocos2d-x-3.x/Cocos2dxAtlasNode.h
+++ b/renderer/cocos2d-x-3.x/Cocos2dxAtlasNode.h
@@ -9,6 +9,7 @@
 #include "BytesType.h"
 #include "CCTextureAtlas.h"
 #include "CCQuadCommand.h"
+#include "cocos2d.h"
 NS_CC_BEGIN
 
 /**


### PR DESCRIPTION
编译OK。
修改了一处矩阵计算错误，导致各个骨骼显示错位的问题。
这看起来不像是DragonBones的问题，而是cocos2d-x本身的问题（class Renderer）。
先通过一段比较山寨的代码，绕过class Render，实现正确的显示。
这样做丧失了class Renderer的性能优势（自动batch）。

等一段时间，看cocos2d-x官方是否会处理这个问题。
