### PR TITLE
remove cocos2dx 3.3 from ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: cpp
 env:
   matrix:
+  fast_finish: true
   #- GEN_BINDING=YES
   #- GEN_COCOS_FILES=YES
   # - PLATFORM=mac-ios PUSH_TO_MAC=YES
-  - PLATFORM=linux DEBUG=1 CC_COMPILER=gcc CXX_COMPILER=g++ C2DX_VER=3.3
+  # - PLATFORM=linux DEBUG=1 CC_COMPILER=gcc CXX_COMPILER=g++ C2DX_VER=3.3
   - PLATFORM=linux DEBUG=1 CC_COMPILER=gcc CXX_COMPILER=g++ C2DX_VER=3.2
   # Disable clang build on linux temporarily since we're using "-stdlib=libc++ " which wasn't installed on travis machine.
   # - PLATFORM=linux DEBUG=1 CC_COMPILER=clang CXX_COMPILER=clang++
@@ -12,7 +13,7 @@ env:
   # port currently builds.  TODO(sbc): Re-enable all architectures.
   # Disabled travis-ci build for native client port since it doesn't support std::thread, std::mutex.
   # - PLATFORM=nacl DEBUG=1 NACL_ARCH=arm
-  - PLATFORM=android CC_COMPILER=gcc CXX_COMPILER=g++ C2DX_VER=3.3
+  # - PLATFORM=android CC_COMPILER=gcc CXX_COMPILER=g++ C2DX_VER=3.3
   - PLATFORM=android CC_COMPILER=gcc CXX_COMPILER=g++ C2DX_VER=3.2
   # - PLATFORM=emscripten DEBUG=1
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 env:
   matrix:
-  fast_finish: true
+    fast_finish: true
   #- GEN_BINDING=YES
   #- GEN_COCOS_FILES=YES
   # - PLATFORM=mac-ios PUSH_TO_MAC=YES

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: cpp
+
+matrix:
+  fast_finish: true
 env:
   matrix:
-    fast_finish: true
   #- GEN_BINDING=YES
   #- GEN_COCOS_FILES=YES
   # - PLATFORM=mac-ios PUSH_TO_MAC=YES


### PR DESCRIPTION
测试两个版本使得travis-ci的内存不够用，造成很大概率编译失败