### PR TITLE
namespaced private rapidjson to prevent conflicts

### DIFF
--- a/DragonBones/src/dragonBones/parsers/JSONDataParser.cpp
+++ b/DragonBones/src/dragonBones/parsers/JSONDataParser.cpp
@@ -5,7 +5,7 @@ DRAGONBONES_NAMESPACE_BEGIN
 JSONDataParser::JSONDataParser() {}
 JSONDataParser::~JSONDataParser() {}
 
-ArmatureData * JSONDataParser::_parseArmature(const rapidjson::Value & rawData)
+ArmatureData * JSONDataParser::_parseArmature(const dragonBones_rapidjson::Value & rawData)
 {
     const auto armature = BaseObject::borrowObject<ArmatureData>();
     armature->name = _getString(rawData, NAME, "");
@@ -95,7 +95,7 @@ ArmatureData * JSONDataParser::_parseArmature(const rapidjson::Value & rawData)
     return armature;
 }
 
-BoneData * JSONDataParser::_parseBone(const rapidjson::Value & rawData)
+BoneData * JSONDataParser::_parseBone(const dragonBones_rapidjson::Value & rawData)
 {
     const auto bone = BaseObject::borrowObject<BoneData>();
     bone->name = _getString(rawData, NAME, "");
@@ -117,7 +117,7 @@ BoneData * JSONDataParser::_parseBone(const rapidjson::Value & rawData)
     return bone;
 }
 
-void JSONDataParser::_parseIK(const rapidjson::Value & rawData)
+void JSONDataParser::_parseIK(const dragonBones_rapidjson::Value & rawData)
 {
     const auto bone = this->_armature->getBone(_getString(rawData, rawData.HasMember(BONE) ? BONE : NAME, ""));
     if (bone)
@@ -142,7 +142,7 @@ void JSONDataParser::_parseIK(const rapidjson::Value & rawData)
     }
 }
 
-SlotData * JSONDataParser::_parseSlot(const rapidjson::Value& rawData, int zOrder)
+SlotData * JSONDataParser::_parseSlot(const dragonBones_rapidjson::Value& rawData, int zOrder)
 {
     const auto slot = BaseObject::borrowObject<SlotData>();
     slot->name = _getString(rawData, NAME, "");
@@ -190,7 +190,7 @@ SlotData * JSONDataParser::_parseSlot(const rapidjson::Value& rawData, int zOrde
     return slot;
 }
 
-SkinData * JSONDataParser::_parseSkin(const rapidjson::Value & rawData)
+SkinData * JSONDataParser::_parseSkin(const dragonBones_rapidjson::Value & rawData)
 {
     const auto skin = BaseObject::borrowObject<SkinData>();
     skin->name = _getString(rawData, NAME, "__default");
@@ -219,7 +219,7 @@ SkinData * JSONDataParser::_parseSkin(const rapidjson::Value & rawData)
     return skin;
 }
 
-SlotDisplayDataSet * JSONDataParser::_parseSlotDisplaySet(const rapidjson::Value & rawData)
+SlotDisplayDataSet * JSONDataParser::_parseSlotDisplaySet(const dragonBones_rapidjson::Value & rawData)
 {
     const auto slotDisplayDataSet = BaseObject::borrowObject<SlotDisplayDataSet>();
     slotDisplayDataSet->slot = this->_armature->getSlot(_getString(rawData, NAME, ""));
@@ -243,7 +243,7 @@ SlotDisplayDataSet * JSONDataParser::_parseSlotDisplaySet(const rapidjson::Value
     return slotDisplayDataSet;
 }
 
-DisplayData * JSONDataParser::_parseDisplay(const rapidjson::Value & rawData)
+DisplayData * JSONDataParser::_parseDisplay(const dragonBones_rapidjson::Value & rawData)
 {
     const auto display = BaseObject::borrowObject<DisplayData>();
     display->name = _getString(rawData, NAME, "");
@@ -298,7 +298,7 @@ DisplayData * JSONDataParser::_parseDisplay(const rapidjson::Value & rawData)
     return display;
 }
 
-MeshData * JSONDataParser::_parseMesh(const rapidjson::Value & rawData)
+MeshData * JSONDataParser::_parseMesh(const dragonBones_rapidjson::Value & rawData)
 {
     const auto mesh = BaseObject::borrowObject<MeshData>();
 
@@ -411,7 +411,7 @@ MeshData * JSONDataParser::_parseMesh(const rapidjson::Value & rawData)
     return mesh;
 }
 
-AnimationData * JSONDataParser::_parseAnimation(const rapidjson::Value & rawData) const
+AnimationData * JSONDataParser::_parseAnimation(const dragonBones_rapidjson::Value & rawData) const
 {
     const auto animation = BaseObject::borrowObject<AnimationData>();
     animation->name = _getString(rawData, NAME, "__default");
@@ -539,7 +539,7 @@ AnimationData * JSONDataParser::_parseAnimation(const rapidjson::Value & rawData
     return animation;
 }
 
-BoneTimelineData * JSONDataParser::_parseBoneTimeline(const rapidjson::Value& rawData) const
+BoneTimelineData * JSONDataParser::_parseBoneTimeline(const dragonBones_rapidjson::Value& rawData) const
 {
     const auto timeline = BaseObject::borrowObject<BoneTimelineData>();
     timeline->bone = this->_armature->getBone(_getString(rawData, NAME, ""));
@@ -597,7 +597,7 @@ BoneTimelineData * JSONDataParser::_parseBoneTimeline(const rapidjson::Value& ra
     return timeline;
 }
 
-SlotTimelineData * JSONDataParser::_parseSlotTimeline(const rapidjson::Value& rawData) const
+SlotTimelineData * JSONDataParser::_parseSlotTimeline(const dragonBones_rapidjson::Value& rawData) const
 {
     const auto timeline = BaseObject::borrowObject<SlotTimelineData>();
     timeline->slot = this->_armature->getSlot(_getString(rawData, NAME, ""));
@@ -612,7 +612,7 @@ SlotTimelineData * JSONDataParser::_parseSlotTimeline(const rapidjson::Value& ra
     return timeline;
 }
 
-FFDTimelineData * JSONDataParser::_parseFFDTimeline(const rapidjson::Value& rawData) const
+FFDTimelineData * JSONDataParser::_parseFFDTimeline(const dragonBones_rapidjson::Value& rawData) const
 {
     const auto timeline = BaseObject::borrowObject<FFDTimelineData>();
     timeline->skin = this->_armature->getSkin(_getString(rawData, SKIN, ""));
@@ -637,7 +637,7 @@ FFDTimelineData * JSONDataParser::_parseFFDTimeline(const rapidjson::Value& rawD
     return timeline;
 }
 
-AnimationFrameData * JSONDataParser::_parseAnimationFrame(const rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const
+AnimationFrameData * JSONDataParser::_parseAnimationFrame(const dragonBones_rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const
 {
     const auto frame = BaseObject::borrowObject<AnimationFrameData>();
 
@@ -656,7 +656,7 @@ AnimationFrameData * JSONDataParser::_parseAnimationFrame(const rapidjson::Value
     return frame;
 }
 
-BoneFrameData * JSONDataParser::_parseBoneFrame(const rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const
+BoneFrameData * JSONDataParser::_parseBoneFrame(const dragonBones_rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const
 {
     const auto frame = BaseObject::borrowObject<BoneFrameData>();
     frame->parent = this->_armature->getBone(_getString(rawData, PARENT, ""));
@@ -704,7 +704,7 @@ BoneFrameData * JSONDataParser::_parseBoneFrame(const rapidjson::Value& rawData,
     return frame;
 }
 
-SlotFrameData * JSONDataParser::_parseSlotFrame(const rapidjson::Value & rawData, unsigned frameStart, unsigned frameCount) const
+SlotFrameData * JSONDataParser::_parseSlotFrame(const dragonBones_rapidjson::Value & rawData, unsigned frameStart, unsigned frameCount) const
 {
     const auto frame = BaseObject::borrowObject<SlotFrameData>();
     frame->displayIndex = _getNumber(rawData, DISPLAY_INDEX, (int)0);
@@ -741,7 +741,7 @@ SlotFrameData * JSONDataParser::_parseSlotFrame(const rapidjson::Value & rawData
     return frame;
 }
 
-ExtensionFrameData * JSONDataParser::_parseFFDFrame(const rapidjson::Value & rawData, unsigned frameStart, unsigned frameCount) const
+ExtensionFrameData * JSONDataParser::_parseFFDFrame(const dragonBones_rapidjson::Value & rawData, unsigned frameStart, unsigned frameCount) const
 {
     const auto frame  = BaseObject::borrowObject<ExtensionFrameData>();
     frame->type = (ExtensionType)_getNumber(rawData, TYPE, (int)ExtensionType::FFD);
@@ -798,7 +798,7 @@ ExtensionFrameData * JSONDataParser::_parseFFDFrame(const rapidjson::Value & raw
     return frame;
 }
 
-void JSONDataParser::_parseActionData(const rapidjson::Value& rawData, std::vector<ActionData*>& actions, BoneData * bone, SlotData * slot) const
+void JSONDataParser::_parseActionData(const dragonBones_rapidjson::Value& rawData, std::vector<ActionData*>& actions, BoneData * bone, SlotData * slot) const
 {
     const auto& actionsObject = rawData.HasMember(ACTION) ? rawData[ACTION] : (rawData.HasMember(ACTIONS) ? rawData[ACTIONS] : rawData[DEFAULT_ACTIONS]);
 
@@ -891,7 +891,7 @@ void JSONDataParser::_parseActionData(const rapidjson::Value& rawData, std::vect
     }
 }
 
-void JSONDataParser::_parseEventData(const rapidjson::Value& rawData, std::vector<EventData*>& events, BoneData* bone, SlotData* slot) const
+void JSONDataParser::_parseEventData(const dragonBones_rapidjson::Value& rawData, std::vector<EventData*>& events, BoneData* bone, SlotData* slot) const
 {
     if (rawData.HasMember(SOUND))
     {
@@ -920,7 +920,7 @@ void JSONDataParser::_parseEventData(const rapidjson::Value& rawData, std::vecto
     }
 }
 
-void JSONDataParser::_parseTransform(const rapidjson::Value& rawData, Transform& transform) const
+void JSONDataParser::_parseTransform(const dragonBones_rapidjson::Value& rawData, Transform& transform) const
 {
     transform.x = _getNumber(rawData, X, 0.f) * this->_armatureScale;
     transform.y = _getNumber(rawData, Y, 0.f) * this->_armatureScale;
@@ -930,7 +930,7 @@ void JSONDataParser::_parseTransform(const rapidjson::Value& rawData, Transform&
     transform.scaleY = _getNumber(rawData, SCALE_Y, 1.f);
 }
 
-void JSONDataParser::_parseColorTransform(const rapidjson::Value& rawData, ColorTransform& color) const
+void JSONDataParser::_parseColorTransform(const dragonBones_rapidjson::Value& rawData, ColorTransform& color) const
 {
     color.alphaMultiplier = _getNumber(rawData, ALPHA_MULTIPLIER, (int)100) * 0.01f;
     color.redMultiplier = _getNumber(rawData, RED_MULTIPLIER, (int)100) * 0.01f;
@@ -946,7 +946,7 @@ DragonBonesData * JSONDataParser::parseDragonBonesData(const char* rawData, floa
 {
     if (rawData)
     {
-        rapidjson::Document document;
+        dragonBones_rapidjson::Document document;
         document.Parse(rawData);
 
         std::string version = _getString(document, VERSION, "");
@@ -1003,7 +1003,7 @@ void JSONDataParser::parseTextureAtlasData(const char* rawData, TextureAtlasData
 {
     if (rawData)
     {
-        rapidjson::Document document;
+        dragonBones_rapidjson::Document document;
         document.Parse(rawData);
 
         textureAtlasData.name = _getString(document, NAME, "");

--- a/DragonBones/src/dragonBones/parsers/JSONDataParser.h
+++ b/DragonBones/src/dragonBones/parsers/JSONDataParser.h
@@ -1,6 +1,8 @@
 #ifndef DRAGONBONES_JSON_DATA_PARSER_H
 #define DRAGONBONES_JSON_DATA_PARSER_H
 
+#define RAPIDJSON_NAMESPACE dragonBones_rapidjson
+
 #include "DataParser.h"
 #include "rapidjson/document.h"
 
@@ -9,7 +11,7 @@ DRAGONBONES_NAMESPACE_BEGIN
 class JSONDataParser : public DataParser
 {
 protected:
-    inline static bool _getBoolean(const rapidjson::Value& rawData, const char*& key, bool defaultValue)
+    inline static bool _getBoolean(const dragonBones_rapidjson::Value& rawData, const char*& key, bool defaultValue)
     {
         if (rawData.HasMember(key))
         {
@@ -44,7 +46,7 @@ protected:
         return defaultValue;
     }
 
-    inline static unsigned _getNumber(const rapidjson::Value& rawData, const char*& key, unsigned defaultValue)
+    inline static unsigned _getNumber(const dragonBones_rapidjson::Value& rawData, const char*& key, unsigned defaultValue)
     {
         if (rawData.HasMember(key))
         {
@@ -54,7 +56,7 @@ protected:
         return defaultValue;
     }
 
-    inline static int _getNumber(const rapidjson::Value& rawData, const char*& key, int defaultValue)
+    inline static int _getNumber(const dragonBones_rapidjson::Value& rawData, const char*& key, int defaultValue)
     {
         if (rawData.HasMember(key))
         {
@@ -64,7 +66,7 @@ protected:
         return defaultValue;
     }
 
-    inline static float _getNumber(const rapidjson::Value& rawData, const char*& key, float defaultValue)
+    inline static float _getNumber(const dragonBones_rapidjson::Value& rawData, const char*& key, float defaultValue)
     {
         if (rawData.HasMember(key) && rawData[key].IsNumber())
         {
@@ -74,7 +76,7 @@ protected:
         return defaultValue;
     }
 
-    inline static std::string _getString(const rapidjson::Value& rawData, const char*& key, const std::string& defaultValue)
+    inline static std::string _getString(const dragonBones_rapidjson::Value& rawData, const char*& key, const std::string& defaultValue)
     {
         if (rawData.HasMember(key))
         {
@@ -84,7 +86,7 @@ protected:
         return defaultValue;
     }
 
-    inline static int _getParameter(const rapidjson::Value& rawData, std::size_t index, int defaultValue)
+    inline static int _getParameter(const dragonBones_rapidjson::Value& rawData, std::size_t index, int defaultValue)
     {
         if (rawData.Size() > index)
         {
@@ -94,7 +96,7 @@ protected:
         return defaultValue;
     }
 
-    inline static float _getParameter(const rapidjson::Value& rawData, std::size_t index, float defaultValue)
+    inline static float _getParameter(const dragonBones_rapidjson::Value& rawData, std::size_t index, float defaultValue)
     {
         if (rawData.Size() > index)
         {
@@ -104,7 +106,7 @@ protected:
         return defaultValue;
     }
 
-    inline static std::string _getParameter(const rapidjson::Value& rawData, std::size_t index, const std::string& defaultValue)
+    inline static std::string _getParameter(const dragonBones_rapidjson::Value& rawData, std::size_t index, const std::string& defaultValue)
     {
         if (rawData.Size() > index)
         {
@@ -122,27 +124,27 @@ private:
     DRAGONBONES_DISALLOW_COPY_AND_ASSIGN(JSONDataParser);
 
 protected:
-    virtual ArmatureData* _parseArmature(const rapidjson::Value& rawData);
-    virtual BoneData* _parseBone(const rapidjson::Value& rawData);
-    virtual void _parseIK(const rapidjson::Value& rawData);
-    virtual SlotData* _parseSlot(const rapidjson::Value& rawData, int zOrder);
-    virtual SkinData* _parseSkin(const rapidjson::Value& rawData);
-    virtual SlotDisplayDataSet* _parseSlotDisplaySet(const rapidjson::Value& rawData);
-    virtual DisplayData* _parseDisplay(const rapidjson::Value& rawData);
-    virtual MeshData* _parseMesh(const rapidjson::Value& rawData);
-    virtual AnimationData* _parseAnimation(const rapidjson::Value& rawData) const;
-    virtual BoneTimelineData* _parseBoneTimeline(const rapidjson::Value& rawData) const;
-    virtual SlotTimelineData* _parseSlotTimeline(const rapidjson::Value& rawData) const;
-    virtual FFDTimelineData* _parseFFDTimeline(const rapidjson::Value& rawData) const;
-    virtual AnimationFrameData* _parseAnimationFrame(const rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const;
-    virtual BoneFrameData* _parseBoneFrame(const rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const;
-    virtual SlotFrameData* _parseSlotFrame(const rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const;
-    virtual ExtensionFrameData* _parseFFDFrame(const rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const;
-    virtual void _parseActionData(const rapidjson::Value& rawData, std::vector<ActionData*>& actions, BoneData* bone, SlotData* slot) const;
-    virtual void _parseEventData(const rapidjson::Value& rawData, std::vector<EventData*>& events, BoneData* bone, SlotData* slot) const;
+    virtual ArmatureData* _parseArmature(const dragonBones_rapidjson::Value& rawData);
+    virtual BoneData* _parseBone(const dragonBones_rapidjson::Value& rawData);
+    virtual void _parseIK(const dragonBones_rapidjson::Value& rawData);
+    virtual SlotData* _parseSlot(const dragonBones_rapidjson::Value& rawData, int zOrder);
+    virtual SkinData* _parseSkin(const dragonBones_rapidjson::Value& rawData);
+    virtual SlotDisplayDataSet* _parseSlotDisplaySet(const dragonBones_rapidjson::Value& rawData);
+    virtual DisplayData* _parseDisplay(const dragonBones_rapidjson::Value& rawData);
+    virtual MeshData* _parseMesh(const dragonBones_rapidjson::Value& rawData);
+    virtual AnimationData* _parseAnimation(const dragonBones_rapidjson::Value& rawData) const;
+    virtual BoneTimelineData* _parseBoneTimeline(const dragonBones_rapidjson::Value& rawData) const;
+    virtual SlotTimelineData* _parseSlotTimeline(const dragonBones_rapidjson::Value& rawData) const;
+    virtual FFDTimelineData* _parseFFDTimeline(const dragonBones_rapidjson::Value& rawData) const;
+    virtual AnimationFrameData* _parseAnimationFrame(const dragonBones_rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const;
+    virtual BoneFrameData* _parseBoneFrame(const dragonBones_rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const;
+    virtual SlotFrameData* _parseSlotFrame(const dragonBones_rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const;
+    virtual ExtensionFrameData* _parseFFDFrame(const dragonBones_rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount) const;
+    virtual void _parseActionData(const dragonBones_rapidjson::Value& rawData, std::vector<ActionData*>& actions, BoneData* bone, SlotData* slot) const;
+    virtual void _parseEventData(const dragonBones_rapidjson::Value& rawData, std::vector<EventData*>& events, BoneData* bone, SlotData* slot) const;
 
     template<class T>
-    void _parseTweenFrame(const rapidjson::Value& rawData, TweenFrameData<T>& frame, unsigned frameStart, unsigned frameCount) const
+    void _parseTweenFrame(const dragonBones_rapidjson::Value& rawData, TweenFrameData<T>& frame, unsigned frameStart, unsigned frameCount) const
     {
         _parseFrame(rawData, frame, frameStart, frameCount);
 
@@ -184,7 +186,7 @@ protected:
     }
 
     template<class T>
-    void _parseFrame(const rapidjson::Value& rawData, FrameData<T>& frame, unsigned frameStart, unsigned frameCount) const
+    void _parseFrame(const dragonBones_rapidjson::Value& rawData, FrameData<T>& frame, unsigned frameStart, unsigned frameCount) const
     {
         frame.position = (float)frameStart / this->_armature->frameRate;
         frame.duration = (float)frameCount / this->_armature->frameRate;
@@ -192,9 +194,9 @@ protected:
 
     template<class T>
     void _parseTimeline(
-        const rapidjson::Value& rawData,
+        const dragonBones_rapidjson::Value& rawData,
         TimelineData<T>& timeline,
-        const std::function<T*(const rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount)>& frameParser) const
+        const std::function<T*(const dragonBones_rapidjson::Value& rawData, unsigned frameStart, unsigned frameCount)>& frameParser) const
     {
         timeline.scale = _getNumber(rawData, SCALE, 1.f);
         timeline.offset = _getNumber(rawData, OFFSET, 0.f);
@@ -274,8 +276,8 @@ protected:
         _timeline = nullptr;
     }
 
-    virtual void _parseTransform(const rapidjson::Value& rawData, Transform& transform) const;
-    virtual void _parseColorTransform(const rapidjson::Value& rawData, ColorTransform& color) const;
+    virtual void _parseTransform(const dragonBones_rapidjson::Value& rawData, Transform& transform) const;
+    virtual void _parseColorTransform(const dragonBones_rapidjson::Value& rawData, ColorTransform& color) const;
 
 public:
     virtual DragonBonesData* parseDragonBonesData(const char* rawData, float scale = 1.f) override;


### PR DESCRIPTION
cocos2dx has its own rapidjson and the linker picks (usually) that one over the DragonBones' one. This causes crashes in the allocator when using mismatching versions of the two or even different build settings.

Using a different namespace than the default "rapidjson" allows the two distinct implementations to co-exist.