### PR TITLE
Fixes for Cocos2d-x 3.13

### DIFF
--- a/Cocos2DX_3.x/src/dragonBones/cocos2dx/CCArmatureDisplay.cpp
+++ b/Cocos2DX_3.x/src/dragonBones/cocos2dx/CCArmatureDisplay.cpp
@@ -140,7 +140,7 @@ bool DBCCSprite::_checkVisibility(const cocos2d::Mat4& transform, const cocos2d:
 void DBCCSprite::draw(cocos2d::Renderer* renderer, const cocos2d::Mat4& transform, uint32_t flags)
 {
 #if CC_USE_CULLING
-    const auto& rect = this->_polyInfo.rect;
+    const auto& rect = this->_polyInfo.getRect();
 
     // Don't do calculate the culling if the transform was not updated
     auto visitingCamera = cocos2d::Camera::getVisitingCamera();

--- a/Cocos2DX_3.x/src/dragonBones/cocos2dx/CCSlot.cpp
+++ b/Cocos2DX_3.x/src/dragonBones/cocos2dx/CCSlot.cpp
@@ -239,9 +239,9 @@ void CCSlot::_updateFrame()
                 triangles.vertCount = (unsigned)(this->_meshData->uvs.size() / 2);
                 triangles.indexCount = (unsigned)(this->_meshData->vertexIndices.size());
                 polygonInfo.setRect(boundsRect); // Copy
+                frameDisplay->setContentSize(boundsRect.size);
                 frameDisplay->setPolygonInfo(polygonInfo);
                 frameDisplay->setColor(frameDisplay->getColor()); // Backup
-                frameDisplay->setContentSize(boundsRect.size);
 
                 if (this->_meshData->skinned)
                 {
@@ -420,10 +420,14 @@ void CCSlot::_updateMesh()
     boundsRect.size.width -= boundsRect.origin.x;
     boundsRect.size.height -= boundsRect.origin.y;
 
-    meshDisplay->getPolygonInfoModify().setRect(boundsRect);
+
+    auto polygonInfo = meshDisplay->getPolygonInfo();
+    polygonInfo.setRect(boundsRect);
 
     const auto& transform = meshDisplay->getNodeToParentTransform();
     meshDisplay->setContentSize(boundsRect.size);
+    meshDisplay->setPolygonInfo(polygonInfo);
+
     _renderDisplay->setNodeToParentTransform(transform);
 }
 

--- a/Cocos2DX_3.x/src/dragonBones/cocos2dx/CCSlot.cpp
+++ b/Cocos2DX_3.x/src/dragonBones/cocos2dx/CCSlot.cpp
@@ -238,7 +238,7 @@ void CCSlot::_updateFrame()
                 triangles.indices = vertexIndices;
                 triangles.vertCount = (unsigned)(this->_meshData->uvs.size() / 2);
                 triangles.indexCount = (unsigned)(this->_meshData->vertexIndices.size());
-                polygonInfo.rect = boundsRect; // Copy
+                polygonInfo.setRect(boundsRect); // Copy
                 frameDisplay->setPolygonInfo(polygonInfo);
                 frameDisplay->setColor(frameDisplay->getColor()); // Backup
                 frameDisplay->setContentSize(boundsRect.size);
@@ -419,10 +419,8 @@ void CCSlot::_updateMesh()
 
     boundsRect.size.width -= boundsRect.origin.x;
     boundsRect.size.height -= boundsRect.origin.y;
-    
-    cocos2d::Rect* rect = (cocos2d::Rect*)&meshDisplay->getPolygonInfo().rect;
-    rect->origin = boundsRect.origin; // copy
-    rect->size = boundsRect.size; // copy
+
+    meshDisplay->getPolygonInfoModify().setRect(boundsRect);
 
     const auto& transform = meshDisplay->getNodeToParentTransform();
     meshDisplay->setContentSize(boundsRect.size);

--- a/DragonBones/src/dragonBones/animation/WorldClock.cpp
+++ b/DragonBones/src/dragonBones/animation/WorldClock.cpp
@@ -102,7 +102,7 @@ void WorldClock::remove(IAnimateble* value)
 
 void WorldClock::clear()
 {
-    for (auto animateble : _animatebles)
+    for (auto& animateble : _animatebles)
     {
         animateble = nullptr;
     }


### PR DESCRIPTION
These fixes should allow the dragonbones cocos2d-x code to be compiled with at least version 3.13 of cocos2d-x.

There is also a bug fix for segfaults occuring when using dragonbones meshes and cocos2d-x 3.13.