### PR TITLE
fix memory leak 

### DIFF
--- a/DragonBones/src/dragonBones/model/TimelineData.h
+++ b/DragonBones/src/dragonBones/model/TimelineData.h
@@ -30,15 +30,16 @@ protected:
         scale = 1.f;
         offset = 0.f;
 
-        T* prevFrame = nullptr;
-        for (const auto frame : frames)
-        {
-            if (prevFrame && frame != prevFrame)
-            {
-                prevFrame->returnToPool();
+        std::vector<T*> deleteFrames;
+        for (const auto frame : frames) {
+            auto i = std::find(deleteFrames.begin(), deleteFrames.end(), frame);
+            if (i == deleteFrames.end()) {
+                deleteFrames.push_back(frame);
             }
+        }
 
-            prevFrame = frame;
+        for (const auto frame : deleteFrames) {
+            frame->returnToPool();
         }
 
         frames.clear();


### PR DESCRIPTION
Memory leak from `TimelineData.h#Line33-41` 
I think previous code have never called "returnToPool" for the last instance in frame list.